### PR TITLE
Add default linux .desktop location and unificate a project name 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 tui-launcher
+gofi

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+build: 
+	go build -o gofi ./
+run: build
+	./gofi

--- a/app.go
+++ b/app.go
@@ -9,6 +9,10 @@ import (
 )
 
 var desktopDirs = []string{
+	// Default linux .desktop files
+	"/usr/share/applications/",
+	"~/.local/share/applications/",
+	// NixOS .desktop files
 	"~/.nix-profile/share/applications",
 	"/run/current-system/sw/share/applications",
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "TUI Launcher for NixOS";
+  description = "Gofi - TUI Launcher for NixOS";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs";
@@ -12,7 +12,7 @@
     pkgs = nixpkgs.legacyPackages.x86_64-linux;
   in {
     packages.x86_64-linux.default = pkgs.buildGoModule {
-      pname = "tui-launcher";
+      pname = "gofi-launcher";
       version = "0.1";
 
       src = ./.;
@@ -29,7 +29,7 @@
 
     apps.x86_64-linux.default = {
       type = "app";
-      program = "${self.packages.x86_64-linux.default}/bin/tui-launcher";
+      program = "${self.packages.x86_64-linux.default}/bin/gofi-launcher";
     };
 
     devShells.x86_64-linux.default = pkgs.mkShell {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module zeshi09/tui-launcher
+module zeshi09/gofi_se
 
 go 1.23.6
 

--- a/pinned.go
+++ b/pinned.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 )
 
-var pinnedFile = filepath.Join(os.Getenv("HOME"), ".config", "tui-launcher", "pinned.json")
+var pinnedFile = filepath.Join(os.Getenv("HOME"), ".config", "gofi-launcher", "pinned.json")
 
 func savePinnedApps() {
 	os.MkdirAll(filepath.Dir(pinnedFile), 0755)


### PR DESCRIPTION
I tried run it in my archlinux and saw empty list of programm. 
In minute of reading code i saw a paths of .desktop files. And this paths not standard for Linux distros different for as NixOS. 

I added default paths in commit

7c2583320893cb30fa3fb752ed4381b8bbb3ed15

And. I think 'tui-launcher' not original name and can cause a problems in find files related gofi  

9868f7fe2f356e5c54456007c206168ae414dcf5

Please test it in on NixOS and send feedback. I not know how it work in diferent cases from my... 