### PR TITLE
Add "most used" sort for apps. 

### DIFF
--- a/app.go
+++ b/app.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 )
 
@@ -72,6 +73,10 @@ func loadApplications() []app {
 		}
 
 	}
+
+	sort.Slice(apps, func(i, j int) bool {
+		return apps[i].Weight() > apps[j].Weight()
+	})
 
 	return apps
 }

--- a/app.go
+++ b/app.go
@@ -17,8 +17,42 @@ var desktopDirs = []string{
 	"/run/current-system/sw/share/applications",
 }
 
+// Object of application in launcher list
+type app struct {
+	name        string
+	cmd         string
+	description string
+	// .desktop file
+	file   string
+	weight int
+}
+
+// Get count how many times user runned this app
+func (a app) Weight() int { return a.weight }
+
+// Get application .desktop file
+func (a app) File() string { return a.file }
+
+func (a app) Title() string       { return a.name }
+func (a app) Description() string { return a.description }
+func (a app) FilterValue() string { return a.name }
+
+var appsWeights = make(map[string]int)
+var appsWeightFile string = filepath.Join(os.Getenv("HOME"), ".config", "gofi-launcher", "gofi-drun.json")
+
+func saveAppsWeight() { writeToJSON(appsWeightFile, appsWeights) }
+func loadAppsWeight() { loadFromJSON(appsWeightFile, &appsWeights) }
+
 func loadApplications() []app {
 	var apps []app
+	loadAppsWeight()
+
+	for file, weight := range appsWeights {
+		parsedApp, err := parseDesktopFile(file, weight)
+		if err == nil && parsedApp.name != "" {
+			apps = append(apps, parsedApp)
+		}
+	}
 
 	for _, dir := range desktopDirs {
 		home, _ := os.UserHomeDir()
@@ -30,8 +64,9 @@ func loadApplications() []app {
 		}
 
 		for _, file := range files {
-			parsedApp, err := parseDesktopFile(file)
-			if err == nil && parsedApp.name != "" {
+			parsedApp, err := parseDesktopFile(file, 0)
+			_, ok := appsWeights[parsedApp.File()]
+			if err == nil && parsedApp.name != "" && !ok {
 				apps = append(apps, parsedApp)
 			}
 		}
@@ -41,7 +76,7 @@ func loadApplications() []app {
 	return apps
 }
 
-func parseDesktopFile(path string) (app, error) {
+func parseDesktopFile(path string, weight int) (app, error) {
 	file, err := os.Open(path)
 	if err != nil {
 		return app{}, err
@@ -79,5 +114,5 @@ func parseDesktopFile(path string) (app, error) {
 		return app{}, err
 	}
 
-	return app{name: name, description: description, cmd: execCmd}, nil
+	return app{name: name, description: description, cmd: execCmd, weight: weight, file: path}, nil
 }

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"sort"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/key"
@@ -27,10 +26,6 @@ type model struct {
 var pinnedApps = make(map[string]bool)
 
 func filterApps(input string, apps []app) []app {
-
-	sort.Slice(apps, func(i, j int) bool {
-		return apps[i].Weight() > apps[j].Weight()
-	})
 
 	if input == "" {
 		return apps
@@ -141,11 +136,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "enter":
 			selected, ok := m.list.SelectedItem().(app)
 			if ok {
-				if w, ok := appsWeights[selected.File()]; ok {
-					appsWeights[selected.file] = w + 1
-				} else {
-					appsWeights[selected.file] = 1
-				}
+				appsWeights[selected.File()] = selected.Weight() + 1
 
 				m.list.Title = fmt.Sprint(selected)
 				saveAppsWeight()

--- a/pinned.go
+++ b/pinned.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 )
@@ -10,29 +8,9 @@ import (
 var pinnedFile = filepath.Join(os.Getenv("HOME"), ".config", "gofi-launcher", "pinned.json")
 
 func savePinnedApps() {
-	os.MkdirAll(filepath.Dir(pinnedFile), 0755)
-
-	data, err := json.MarshalIndent(pinnedApps, "", " ")
-
-	if err != nil {
-		fmt.Println("Saving pinned apps error:", err)
-	}
-
-	err = os.WriteFile(pinnedFile, data, 0644)
-	if err != nil {
-		fmt.Println("Writing pinned apps error:", err)
-	}
+	writeToJSON(pinnedFile, pinnedApps)
 }
 
 func loadPinnedApps() {
-	data, err := os.ReadFile(pinnedFile)
-	if err != nil {
-		fmt.Println("pinned.json not found, make new")
-		return
-	}
-
-	err = json.Unmarshal(data, &pinnedApps)
-	if err != nil {
-		fmt.Println("Loading pinned.json error:", err)
-	}
+	loadFromJSON(pinnedFile, &pinnedApps)
 }

--- a/tools.go
+++ b/tools.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func loadFromJSON(path string, pointer_obj any) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		fmt.Printf("\n%s not found, make new", path)
+		return
+	}
+
+	err = json.Unmarshal(data, &pointer_obj)
+	if err != nil {
+		fmt.Printf("\nLoading %s error: %s", path, err)
+	}
+}
+
+func writeToJSON(path string, obj any) {
+	os.MkdirAll(filepath.Dir(path), 0755)
+
+	data, err := json.MarshalIndent(obj, "", " ")
+
+	if err != nil {
+		fmt.Printf("\nSaving %s apps error: %s", path, err.Error())
+	}
+
+	err = os.WriteFile(path, data, 0644)
+	if err != nil {
+		fmt.Printf("\nWriting %s apps error: %s", path, err.Error())
+	}
+}


### PR DESCRIPTION
Add "most used" sort for apps. 

Its should rid for often searching useable apps 

And rid for a need in pin all needed apps

I implement it as "pinned apps" and i taked general function for load/dump files in ./tools.go